### PR TITLE
Bump to 1.4.0.RELEASE

### DIFF
--- a/chapter03/3.4_hajiboot-flyway/pom.xml
+++ b/chapter03/3.4_hajiboot-flyway/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.4.0.RC1</version>
+		<version>1.4.0.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 


### PR DESCRIPTION
All other pom.xml looks to have been updated to 1.4.0.RELEASE, but in this file, `version` hasn't been updated although `pluginRepositories` section was removed in [this commit](43e9724d3fe7b05602e94723dd5512c311c2f573). So resolution fails as:

```
[FATAL] Non-resolvable parent POM for com.example:hajiboot-flyway:0.0.1-SNAPSHOT: Failure to find org.springframework.boot:spring-boot-starter-parent:pom:1.4.0.RC1 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced and 'parent.relativePath' points at no local POM @ line 14, column 10
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project com.example:hajiboot-flyway:0.0.1-SNAPSHOT (/private/tmp/hajiboot-samples/chapter03/3.4_hajiboot-flyway/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for com.example:hajiboot-flyway:0.0.1-SNAPSHOT: Failure to find org.springframework.boot:spring-boot-starter-parent:pom:1.4.0.RC1 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced and 'parent.relativePath' points at no local POM @ line 14, column 10 -> [Help 2]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```